### PR TITLE
Run integ tests as part of git workflow instead of build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,6 @@ on:
   push: 
     branches: 
       - master
-
   pull_request:
     branches: 
       - master
@@ -49,3 +48,6 @@ jobs:
     - name: Start Build
       working-directory: ./tmp/pa
       run: ./gradlew build
+    - name: Run Integration Tests
+      working-directory: ./tmp/pa
+      run: ./gradlew integTest

--- a/build.gradle
+++ b/build.gradle
@@ -267,5 +267,3 @@ afterEvaluate {
          tasks = ['build', 'buildRpm', 'buildDeb']
     }
 }
-
-check.dependsOn integTest


### PR DESCRIPTION
This commit makes it so that you can build PA without running
integration tests. This is useful for many reasons, including being able
to build RCA without depending on PA's integration tests and
dramatically reducing build times.

Integration Testing has been added as part of the Github Actions
workflow

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
